### PR TITLE
Support seekable Ranges and Play from Start

### DIFF
--- a/content/browser/media/android/browser_media_player_manager.cc
+++ b/content/browser/media/android/browser_media_player_manager.cc
@@ -1,3 +1,4 @@
+// Copyright (c) 2015, NVIDIA CORPORATION. All rights reserved.
 // Copyright 2013 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
@@ -348,6 +349,12 @@ void BrowserMediaPlayerManager::OnVideoSizeChanged(
       width, height));
   if (fullscreen_player_id_ == player_id)
     video_view_->OnVideoSizeChanged(width, height);
+}
+
+void BrowserMediaPlayerManager::OnSeekableRangeChanged(
+    int player_id, int seekableRangeStart, int seekableRangeEnd) {
+  Send(new MediaPlayerMsg_MediaSeekableRangeChanged(RoutingID(), player_id,
+      seekableRangeStart, seekableRangeEnd));
 }
 
 void BrowserMediaPlayerManager::OnWaitingForDecryptionKey(int player_id) {

--- a/content/browser/media/android/browser_media_player_manager.h
+++ b/content/browser/media/android/browser_media_player_manager.h
@@ -1,3 +1,4 @@
+// Copyright (c) 2015, NVIDIA CORPORATION. All rights reserved.
 // Copyright 2013 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
@@ -94,6 +95,7 @@ class CONTENT_EXPORT BrowserMediaPlayerManager
                       const base::TimeDelta& current_time) override;
   void OnError(int player_id, int error) override;
   void OnVideoSizeChanged(int player_id, int width, int height) override;
+  void OnSeekableRangeChanged(int player_id, int seekableRangeStart, int seekableRangeEnd) override;
   void OnWaitingForDecryptionKey(int player_id) override;
 
   media::MediaResourceGetter* GetMediaResourceGetter() override;

--- a/content/common/media/media_player_messages_android.h
+++ b/content/common/media/media_player_messages_android.h
@@ -1,3 +1,4 @@
+// Copyright (c) 2015, NVIDIA CORPORATION. All rights reserved.
 // Copyright (c) 2012 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
@@ -145,6 +146,12 @@ IPC_MESSAGE_ROUTED2(MediaPlayerMsg_SeekRequest,
 IPC_MESSAGE_ROUTED2(MediaPlayerMsg_SeekCompleted,
                     int /* player_id */,
                     base::TimeDelta /* current_time */)
+
+// Seekable Range has changed.
+IPC_MESSAGE_ROUTED3(MediaPlayerMsg_MediaSeekableRangeChanged,
+                    int /* player_id */,
+                    int /* seekableRangeStart */,
+                    int /* seekableRangeEnd */)
 
 // Video size has changed.
 IPC_MESSAGE_ROUTED3(MediaPlayerMsg_MediaVideoSizeChanged,

--- a/content/renderer/media/android/renderer_media_player_manager.cc
+++ b/content/renderer/media/android/renderer_media_player_manager.cc
@@ -1,3 +1,4 @@
+// Copyright (c) 2015, NVIDIA CORPORATION. All rights reserved.
 // Copyright 2013 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
@@ -40,6 +41,8 @@ bool RendererMediaPlayerManager::OnMessageReceived(const IPC::Message& msg) {
     IPC_MESSAGE_HANDLER(MediaPlayerMsg_SeekRequest, OnSeekRequest)
     IPC_MESSAGE_HANDLER(MediaPlayerMsg_SeekCompleted, OnSeekCompleted)
     IPC_MESSAGE_HANDLER(MediaPlayerMsg_MediaError, OnMediaError)
+    IPC_MESSAGE_HANDLER(MediaPlayerMsg_MediaSeekableRangeChanged,
+                        OnSeekableRangeChanged)
     IPC_MESSAGE_HANDLER(MediaPlayerMsg_MediaVideoSizeChanged,
                         OnVideoSizeChanged)
     IPC_MESSAGE_HANDLER(MediaPlayerMsg_MediaTimeUpdate, OnTimeUpdate)
@@ -181,6 +184,14 @@ void RendererMediaPlayerManager::OnVideoSizeChanged(int player_id,
   media::RendererMediaPlayerInterface* player = GetMediaPlayer(player_id);
   if (player)
     player->OnVideoSizeChanged(width, height);
+}
+
+void RendererMediaPlayerManager::OnSeekableRangeChanged(int player_id,
+                                                    int seekableRangeStart,
+                                                    int seekableRangeEnd) {
+  media::RendererMediaPlayerInterface* player = GetMediaPlayer(player_id);
+  if (player)
+    player->OnSeekableRangeChanged(seekableRangeStart, seekableRangeEnd);
 }
 
 void RendererMediaPlayerManager::OnTimeUpdate(

--- a/content/renderer/media/android/renderer_media_player_manager.h
+++ b/content/renderer/media/android/renderer_media_player_manager.h
@@ -1,3 +1,4 @@
+// Copyright (c) 2015, NVIDIA CORPORATION. All rights reserved.
 // Copyright 2013 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
@@ -128,6 +129,7 @@ class RendererMediaPlayerManager :
   void OnSeekCompleted(int player_id,
                        const base::TimeDelta& current_timestamp);
   void OnMediaError(int player_id, int error);
+  void OnSeekableRangeChanged(int player_id, int seekableRangeStart, int seekableRangeEnd);
   void OnVideoSizeChanged(int player_id, int width, int height);
   void OnTimeUpdate(int player_id,
                     base::TimeDelta current_timestamp,

--- a/content/renderer/media/android/webmediaplayer_android.cc
+++ b/content/renderer/media/android/webmediaplayer_android.cc
@@ -1,3 +1,4 @@
+// Copyright (c) 2015, NVIDIA CORPORATION. All rights reserved.
 // Copyright 2013 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
@@ -216,6 +217,8 @@ WebMediaPlayerAndroid::WebMediaPlayerAndroid(
       allow_stored_credentials_(false),
       is_local_resource_(false),
       interpolator_(&default_tick_clock_),
+      seekableRangeStart_(-1),
+      seekableRangeEnd_(-1),
       frame_id_(frame_id),
       enable_texture_copy_(enable_texture_copy),
       suppress_deleting_texture_(false),
@@ -636,6 +639,12 @@ blink::WebTimeRanges WebMediaPlayerAndroid::seekable() const {
   // TODO(dalecurtis): Technically this allows seeking on media which return an
   // infinite duration.  While not expected, disabling this breaks semi-live
   // players, http://crbug.com/427412.
+
+  // For sliding window with valid seekable ranges, They should not be hardcoded.
+  if (seekableRangeStart_ >= 0 && seekableRangeEnd_ >= 0) {
+    const blink::WebTimeRange seekable_range(seekableRangeStart_, seekableRangeEnd_);
+    return blink::WebTimeRanges(&seekable_range, 1);
+  }
   const blink::WebTimeRange seekable_range(0.0, duration());
   return blink::WebTimeRanges(&seekable_range, 1);
 }
@@ -915,6 +924,13 @@ void WebMediaPlayerAndroid::OnMediaError(int error_type) {
       break;
   }
   client_->repaint();
+}
+
+void WebMediaPlayerAndroid::OnSeekableRangeChanged(int seekableRangeStart, int seekableRangeEnd)
+{
+    LOG(INFO) << __FUNCTION__ << "(" << seekableRangeStart <<" : " <<seekableRangeEnd<< ")";
+    seekableRangeStart_ = seekableRangeStart;
+    seekableRangeEnd_ = seekableRangeEnd;
 }
 
 void WebMediaPlayerAndroid::OnVideoSizeChanged(int width, int height) {

--- a/content/renderer/media/android/webmediaplayer_android.h
+++ b/content/renderer/media/android/webmediaplayer_android.h
@@ -1,3 +1,4 @@
+// Copyright (c) 2015, NVIDIA CORPORATION. All rights reserved.
 // Copyright 2013 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
@@ -200,6 +201,7 @@ class WebMediaPlayerAndroid
   void OnMediaError(int error_type) override;
   void OnVideoSizeChanged(int width, int height) override;
   void OnDurationChanged(const base::TimeDelta& duration);
+  void OnSeekableRangeChanged(int seekableRangeStart, int seekableRangeEnd) override;
 
   // Called to update the current time.
   void OnTimeUpdate(base::TimeDelta current_timestamp,
@@ -495,6 +497,12 @@ class WebMediaPlayerAndroid
   // Tracks the most recent media time update and provides interpolated values
   // as playback progresses.
   media::TimeDeltaInterpolator interpolator_;
+
+  // SeekableRange Start.
+  int seekableRangeStart_;
+
+  // SeekableRange End.
+  int seekableRangeEnd_;
 
   std::unique_ptr<MediaSourceDelegate> media_source_delegate_;
 

--- a/media/base/android/java/src/org/chromium/media/MediaPlayerBridge.java
+++ b/media/base/android/java/src/org/chromium/media/MediaPlayerBridge.java
@@ -1,3 +1,4 @@
+// Copyright (c) 2015, NVIDIA CORPORATION. All rights reserved.
 // Copyright 2013 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
@@ -324,6 +325,10 @@ public class MediaPlayerBridge {
 
     protected void setOnErrorListener(MediaPlayer.OnErrorListener listener) {
         getLocalPlayer().setOnErrorListener(listener);
+    }
+
+    protected void setOnInfoListener(MediaPlayer.OnInfoListener listener) {
+        getLocalPlayer().setOnInfoListener(listener);
     }
 
     protected void setOnPreparedListener(MediaPlayer.OnPreparedListener listener) {

--- a/media/base/android/media_player_android.cc
+++ b/media/base/android/media_player_android.cc
@@ -1,3 +1,4 @@
+// Copyright (c) 2015, NVIDIA CORPORATION. All rights reserved.
 // Copyright (c) 2013 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
@@ -82,6 +83,10 @@ void MediaPlayerAndroid::SetCdm(const scoped_refptr<MediaKeys>& /* cdm */) {
 
 void MediaPlayerAndroid::OnVideoSizeChanged(int width, int height) {
   manager_->OnVideoSizeChanged(player_id(), width, height);
+}
+
+void MediaPlayerAndroid::OnSeekableRangeChanged(int seekableRangeStart, int seekableRangeEnd) {
+  manager_->OnSeekableRangeChanged(player_id(), seekableRangeStart, seekableRangeEnd);
 }
 
 void MediaPlayerAndroid::OnMediaError(int error_type) {

--- a/media/base/android/media_player_android.h
+++ b/media/base/android/media_player_android.h
@@ -1,3 +1,4 @@
+// Copyright (c) 2015, NVIDIA CORPORATION. All rights reserved.
 // Copyright (c) 2013 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
@@ -143,6 +144,7 @@ class MEDIA_EXPORT MediaPlayerAndroid {
   // the events needed by MediaPlayerBridge. http://crbug.com/422597.
   // MediaPlayerListener callbacks.
   virtual void OnVideoSizeChanged(int width, int height);
+  virtual void OnSeekableRangeChanged(int seekableRangeStart, int seekableRangeEnd);
   virtual void OnMediaError(int error_type);
   virtual void OnBufferingUpdate(int percent);
   virtual void OnPlaybackComplete();

--- a/media/base/android/media_player_bridge.cc
+++ b/media/base/android/media_player_bridge.cc
@@ -1,3 +1,4 @@
+// Copyright (c) 2015, NVIDIA CORPORATION. All rights reserved.
 // Copyright (c) 2012 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
@@ -430,6 +431,10 @@ void MediaPlayerBridge::UpdateEffectiveVolumeInternal(double effective_volume) {
 
   Java_MediaPlayerBridge_setVolume(env, j_media_player_bridge_.obj(),
                                    effective_volume);
+}
+
+void MediaPlayerBridge::OnSeekableRangeChanged(int seekableRangeStart, int seekableRangeEnd) {
+  MediaPlayerAndroid::OnSeekableRangeChanged(seekableRangeStart, seekableRangeEnd);
 }
 
 void MediaPlayerBridge::OnVideoSizeChanged(int width, int height) {

--- a/media/base/android/media_player_bridge.h
+++ b/media/base/android/media_player_bridge.h
@@ -1,3 +1,4 @@
+// Copyright (c) 2015, NVIDIA CORPORATION. All rights reserved.
 // Copyright (c) 2012 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
@@ -96,6 +97,7 @@ class MEDIA_EXPORT MediaPlayerBridge : public MediaPlayerAndroid {
 
   // MediaPlayerAndroid implementation.
   void OnVideoSizeChanged(int width, int height) override;
+  void OnSeekableRangeChanged(int seekableRangeStart, int seekableRangeEnd) override;
   void OnMediaError(int error_type) override;
   void OnPlaybackComplete() override;
   void OnMediaInterrupted() override;

--- a/media/base/android/media_player_listener.cc
+++ b/media/base/android/media_player_listener.cc
@@ -1,3 +1,4 @@
+// Copyright (c) 2015, NVIDIA CORPORATION. All rights reserved.
 // Copyright (c) 2012 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
@@ -49,6 +50,13 @@ void MediaPlayerListener::OnMediaError(JNIEnv* /* env */,
                                        jint error_type) {
   task_runner_->PostTask(FROM_HERE, base::Bind(
       &MediaPlayerAndroid::OnMediaError, media_player_, error_type));
+}
+
+void MediaPlayerListener::OnSeekableRangeChanged(
+    JNIEnv* /* env */, jobject /* obj */, jint seekableRangeStart, jint seekableRangeEnd) {
+  task_runner_->PostTask(FROM_HERE, base::Bind(
+      &MediaPlayerAndroid::OnSeekableRangeChanged, media_player_,
+      seekableRangeStart, seekableRangeEnd));
 }
 
 void MediaPlayerListener::OnVideoSizeChanged(

--- a/media/base/android/media_player_listener.h
+++ b/media/base/android/media_player_listener.h
@@ -1,3 +1,4 @@
+// Copyright (c) 2015, NVIDIA CORPORATION. All rights reserved.
 // Copyright (c) 2012 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
@@ -37,6 +38,8 @@ class MediaPlayerListener {
  void OnMediaError(JNIEnv* /* env */,
                    const base::android::JavaParamRef<jobject>& /* obj */,
                    jint error_type);
+ void OnSeekableRangeChanged(JNIEnv* /* env */, jobject /* obj */,
+                         jint seekableRangeStart, jint seekableRangeEnd);
  void OnVideoSizeChanged(JNIEnv* /* env */,
                          const base::android::JavaParamRef<jobject>& /* obj */,
                          jint width,

--- a/media/base/android/media_player_manager.h
+++ b/media/base/android/media_player_manager.h
@@ -1,3 +1,4 @@
+// Copyright (c) 2015, NVIDIA CORPORATION. All rights reserved.
 // Copyright (c) 2012 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
@@ -61,6 +62,9 @@ class MEDIA_EXPORT MediaPlayerManager {
 
   // Called when video size has changed. Args: player ID, width, height.
   virtual void OnVideoSizeChanged(int player_id, int width, int height) = 0;
+
+  // Called when seekable range start or end value changed . Args: player ID, seekableRangeStart, seekableRangeEnd.
+  virtual void OnSeekableRangeChanged(int player_id, int seekableRangeStart, int seekableRangeEnd) = 0;
 
   // Called when the player pauses as a new key is required to decrypt
   // encrypted content.

--- a/media/blink/renderer_media_player_interface.h
+++ b/media/blink/renderer_media_player_interface.h
@@ -1,3 +1,4 @@
+// Copyright (c) 2015, NVIDIA CORPORATION. All rights reserved.
 // Copyright 2016 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
@@ -38,6 +39,7 @@ class RendererMediaPlayerInterface {
   virtual void OnSeekRequest(const base::TimeDelta& time_to_seek) = 0;
   virtual void OnSeekComplete(const base::TimeDelta& current_time) = 0;
   virtual void OnMediaError(int error_type) = 0;
+  virtual void OnSeekableRangeChanged(int seekableRangeStart, int seekableRangeEnd) = 0;
   virtual void OnVideoSizeChanged(int width, int height) = 0;
 
   // Called to update the current time.

--- a/media/blink/webmediaplayer_cast_android.cc
+++ b/media/blink/webmediaplayer_cast_android.cc
@@ -1,3 +1,4 @@
+// Copyright (c) 2015, NVIDIA CORPORATION. All rights reserved.
 // Copyright 2016 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
@@ -229,6 +230,10 @@ void WebMediaPlayerCast::OnMediaError(int error_type) {
 }
 
 void WebMediaPlayerCast::OnVideoSizeChanged(int width, int height) {
+  DVLOG(1) << __FUNCTION__;
+}
+
+void WebMediaPlayerCast::OnSeekableRangeChanged(int seekableRangeStart, int seekableRangeEnd) {
   DVLOG(1) << __FUNCTION__;
 }
 

--- a/media/blink/webmediaplayer_cast_android.h
+++ b/media/blink/webmediaplayer_cast_android.h
@@ -1,3 +1,4 @@
+// Copyright (c) 2015, NVIDIA CORPORATION. All rights reserved.
 // Copyright 2016 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
@@ -61,6 +62,7 @@ class WebMediaPlayerCast : public RendererMediaPlayerInterface {
   void OnSeekComplete(const base::TimeDelta& current_time) override;
   void OnMediaError(int error_type) override;
   void OnVideoSizeChanged(int width, int height) override;
+  void OnSeekableRangeChanged(int seekableRangeStart, int seekableRangeEnd) override;
 
   // Called to update the current time.
   void OnTimeUpdate(base::TimeDelta current_timestamp,


### PR DESCRIPTION
Here is the flow of execution:
*) Listen for MEDIA_INFO_METADATA_UPDATE event
*) Get seekableRangeStart and seekableRangeEnd using getMetaData()
*) Propogate the values to native layer and to media_player_android
*) If seekableRanges have valid values, Send them to HTML Media Element
*) Fix clamping issues for current_time and duration for Live streams
