### PR TITLE
HLS metadata extraction to update timestamps

### DIFF
--- a/content/public/android/java/src/org/chromium/content/browser/MediaResourceGetter.java
+++ b/content/public/android/java/src/org/chromium/content/browser/MediaResourceGetter.java
@@ -19,13 +19,19 @@ import org.chromium.base.VisibleForTesting;
 import org.chromium.base.annotations.CalledByNative;
 import org.chromium.base.annotations.JNINamespace;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
 import java.net.URI;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Java counterpart of android MediaResourceGetter.
@@ -33,7 +39,7 @@ import java.util.Map;
 @JNINamespace("content")
 class MediaResourceGetter {
 
-    private static final String TAG = "cr.MediaResourceGetter";
+    private static final String TAG = "cr_MediaResGetter";
     private static final MediaMetadata EMPTY_METADATA = new MediaMetadata(0, 0, 0, false);
 
     private final MediaMetadataRetriever mRetriever = new MediaMetadataRetriever();
@@ -143,11 +149,141 @@ class MediaResourceGetter {
             return EMPTY_METADATA;
         }
 
+        if (isValidHlsUrl(url)) {
+            return doExtractHlsMetadata(url);
+        }
+
         if (!configure(context, url, cookies, userAgent)) {
             Log.e(TAG, "Unable to configure metadata extractor");
             return EMPTY_METADATA;
         }
         return doExtractMetadata();
+    }
+
+    @VisibleForTesting
+    boolean isValidHlsUrl(String url) {
+        URI uri;
+        try {
+            uri = URI.create(url);
+        } catch (IllegalArgumentException  e) {
+            return false;
+        }
+        String scheme = uri.getScheme();
+        return scheme != null
+                && (scheme.equalsIgnoreCase("http") || scheme.equalsIgnoreCase("https"))
+                && uri.getPath() != null && uri.getPath().endsWith(".m3u8");
+    }
+
+    @VisibleForTesting
+    List<String> getHlsMetadataRequest(String url) {
+        if (isValidHlsUrl(url)) {
+            BufferedReader reader = null;
+            List<String> lines = new ArrayList<>();
+            try {
+                HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
+                connection.setRequestMethod("GET");
+                connection.connect();
+                reader = new BufferedReader(new InputStreamReader(connection.getInputStream()));
+                String line = null;
+                while ((line = reader.readLine()) != null) {
+                    line = line.trim();
+                    if (!line.startsWith("##") && !line.equals("#EXTM3U")) {
+                        lines.add(line);
+                    }
+                }
+                return lines;
+            } catch (IOException e) {
+                Log.e(TAG, "Cannot get hls metadata from: %s", url);
+            } finally {
+                if (reader != null) {
+                    try {
+                        reader.close();
+                    } catch (IOException e) {
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    private MediaMetadata extractHlsPlaylist(List<String> lines, int lineOffset, int w, int h) {
+        // Calculate duration inside the playlist metadata
+        final String StreamInfoVodEnd = "#EXT-X-ENDLIST";
+        final String DurationRegex = "^#EXTINF:([0-9\\.]*?),.*?$";
+        final Pattern durationPattern = Pattern.compile(DurationRegex);
+        float duration = 0f;
+        for (int i = lineOffset; i < lines.size(); ++i) {
+            String line = lines.get(i);
+            if (line.equals(StreamInfoVodEnd)) {
+                return new MediaMetadata((int) (duration * 1000), w, h, true);
+            } else {
+                Matcher matcher = durationPattern.matcher(line);
+                if (matcher.find() && matcher.groupCount() == 1) {
+                    try {
+                        duration += Float.parseFloat(matcher.group(1));
+                    } catch (NumberFormatException e) {
+                        Log.e(TAG, "Unable to parse duration from hls stream");
+                        return EMPTY_METADATA;
+                    }
+                }
+            }
+        }
+        // Return 0 for live streams not containing "#EXT-X-ENDLIST"
+        return new MediaMetadata(0, w, h, true);
+    }
+
+    private MediaMetadata doExtractHlsMetadata(String url) {
+        final String StreamInfo = "#EXT-X-STREAM-INF:";
+        final String StreamInfoTargetDuration = "#EXT-X-TARGETDURATION:";
+        final String ResolutionRegex = "^.*?RESOLUTION=(\\d*?)x(\\d+).*?$";
+        int width = 0, height = 0;
+
+        List<String> lines = getHlsMetadataRequest(url);
+        if (lines != null && lines.size() >= 2) {
+            try {
+                final Pattern resolutionPattern = Pattern.compile(ResolutionRegex);
+
+                for (int i = 0; i < lines.size() - 1; ++i) {
+                    if (lines.get(i).startsWith(StreamInfoTargetDuration)) {
+                        // Parse simple playlist for duration, no resolution was specified
+                        return extractHlsPlaylist(lines, i + 1, 0, 0);
+                    } else if (lines.get(i).startsWith(StreamInfo)) {
+                        // Parse Variant Master Playlist
+                        // First find the resolution of stream info: 'resolution=WxH'
+                        Matcher matcher = resolutionPattern.matcher(lines.get(i));
+                        if (matcher.find() && matcher.groupCount() == 2) {
+                            try {
+                                width = Integer.parseInt(matcher.group(1), 10);
+                                height = Integer.parseInt(matcher.group(2), 10);
+                            } catch (NumberFormatException e) {
+                                Log.w(TAG, "Unable to parse resolution from text in hls stream");
+                                width = height = 0;
+                            }
+                        } else {
+                            Log.w(TAG, "Unable to parse resolution from hls stream");
+                        }
+
+                        // Parse the first playlist url to get the duration of the stream
+                        // Append url to base url if it does not start with http or https
+                        String playlistUrl = lines.get(++i);
+                        lines = getHlsMetadataRequest(playlistUrl);
+                        if (lines == null) {
+                            // Relative url, prepend the original url
+                            String rel = url.substring(0,  url.lastIndexOf("/") + 1) + playlistUrl;
+                            lines = getHlsMetadataRequest(rel);
+                            if (lines == null) {
+                                Log.e(TAG, "Cannot parse url from hls playlist: %s", playlistUrl);
+                                return EMPTY_METADATA;
+                            }
+                        }
+                        return extractHlsPlaylist(lines, 0, width, height);
+                    }
+                }
+            } catch (RuntimeException e) {
+                Log.e(TAG, "Unable to extract hls metadata", e);
+            }
+        }
+        return EMPTY_METADATA;
     }
 
     private MediaMetadata doExtractMetadata() {
@@ -235,10 +371,6 @@ class MediaResourceGetter {
                 Log.e(TAG, "Error configuring data source: %s", e.getMessage());
                 return false;
             }
-        }
-        if (uri.getPath() != null && uri.getPath().endsWith(".m3u8")) {
-            // MediaMetadataRetriever does not work with HLS correctly.
-            return false;
         }
         final String host = uri.getHost();
         if (!isLoopbackAddress(host) && !isNetworkReliable(context)) {

--- a/content/public/android/javatests/src/org/chromium/content/browser/MediaResourceGetterTest.java
+++ b/content/public/android/javatests/src/org/chromium/content/browser/MediaResourceGetterTest.java
@@ -17,8 +17,10 @@ import android.util.SparseArray;
 import org.chromium.content.browser.MediaResourceGetter.MediaMetadata;
 
 import java.io.File;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -27,6 +29,7 @@ import java.util.Map;
 @SuppressLint("SdCardPath")
 public class MediaResourceGetterTest extends InstrumentationTestCase {
     private static final String TEST_HTTP_URL = "http://example.com";
+    private static final String TEST_HTTP_HLS_URL = TEST_HTTP_URL + "/file.m3u8";
     private static final String TEST_USER_AGENT = // Anything, really
             "Mozilla/5.0 (Windows NT 6.2; Win64; x64) AppleWebKit/537.36 "
             + "(KHTML, like Gecko) Chrome/32.0.1667.0 Safari/537.36";
@@ -107,6 +110,7 @@ public class MediaResourceGetterTest extends InstrumentationTestCase {
         boolean mThrowExceptionInConfigure = false;
         boolean mThrowExceptionInExtract = false;
         boolean mFileExists = false;
+        Map<String, String> mHlsMockNetworkRequest = null;
 
         // Can't use a real MediaMetadataRetriever as we have no media
         @Override
@@ -171,6 +175,18 @@ public class MediaResourceGetterTest extends InstrumentationTestCase {
         File uriToFile(String path) {
             FakeFile result = new FakeFile(path, mFileExists);
             return result;
+        }
+
+        // Can't use a real openConnection() to get the hls metadata
+        @Override
+        List<String> getHlsMetadataRequest(String url) {
+            if (mHlsMockNetworkRequest != null) {
+                String data = mHlsMockNetworkRequest.get(url);
+                if (data != null) {
+                    return Arrays.asList(data.split("\n"));
+                }
+            }
+            return null;
         }
 
         /**
@@ -591,5 +607,135 @@ public class MediaResourceGetterTest extends InstrumentationTestCase {
     public void testAndroidDeviceOk_GoodModel_AnyVersion() {
         assertTrue(MediaResourceGetter.androidDeviceOk(
                 "Happy Device", android.os.Build.VERSION_CODES.ICE_CREAM_SANDWICH));
+    }
+
+    @SmallTest
+    public void testHls_ValidUrl() {
+        assertTrue(mFakeMRG.isValidHlsUrl(TEST_HTTP_HLS_URL));
+        assertTrue(mFakeMRG.isValidHlsUrl("https://www.test.com/this/is/hls/file.m3u8"));
+    }
+
+    @SmallTest
+    public void testHls_InvalidUrl() {
+        assertFalse(mFakeMRG.isValidHlsUrl("https://www.test.com/this/is/another/file.m3u"));
+        assertFalse(mFakeMRG.isValidHlsUrl("http://www.test.com/this/is/another/file.m3u"));
+        assertFalse(mFakeMRG.isValidHlsUrl("www.test.com/this/is/another/file.m3u8"));
+        assertFalse(mFakeMRG.isValidHlsUrl("www.test.com/this/is/another/file.m3u"));
+        assertFalse(mFakeMRG.isValidHlsUrl(""));
+    }
+
+    @SmallTest
+    public void testExtract_UsingHls_ValidPlaylist_IsVOD() {
+        mFakeMRG.mHlsMockNetworkRequest = new HashMap<String, String>() { {
+                put(TEST_HTTP_HLS_URL,
+                        "#EXTM3U\n"
+                        + "#EXT-X-TARGETDURATION:10\n"
+                        + "#EXT-X-VERSION:3\n"
+                        + "#EXT-X-MEDIA-SEQUENCE:1\n"
+                        + "#EXTINF:10.000,\n"
+                        + "http://www.test.com/segment1.ts,\n"
+                        + "#EXTINF:10.000,\n"
+                        + "http://www.test.com/segment2.ts,\n"
+                        + "#EXTINF:4.500,\n"
+                        + "http://www.test.com/segment3.ts,\n"
+                        + "#EXT-X-ENDLIST");
+            }};
+        final MediaMetadata expected = new MediaMetadata(24500, 0, 0, true);
+        assertEquals(expected, mFakeMRG.extract(mMockContext, TEST_HTTP_HLS_URL, null, null));
+    }
+
+    @SmallTest
+    public void testExtract_UsingHls_ValidPlaylist_IsLive() {
+        mFakeMRG.mHlsMockNetworkRequest = new HashMap<String, String>() { {
+                put(TEST_HTTP_HLS_URL,
+                        "#EXTM3U\n"
+                        + "#EXT-X-TARGETDURATION:10\n"
+                        + "#EXT-X-VERSION:3\n"
+                        + "#EXT-X-MEDIA-SEQUENCE:1\n"
+                        + "#EXTINF:10.000,\n"
+                        + "http://www.test.com/segment1.ts,\n"
+                        + "#EXTINF:10.000,\n"
+                        + "http://www.test.com/segment2.ts,\n"
+                        + "#EXTINF:4.500,\n"
+                        + "http://www.test.com/segment3.ts,");
+            }};
+        final MediaMetadata expected = new MediaMetadata(0, 0, 0, true);
+        assertEquals(expected, mFakeMRG.extract(mMockContext, TEST_HTTP_HLS_URL, null, null));
+    }
+
+    @SmallTest
+    public void testExtract_UsingHls_ValidMasterPlaylist_ValidResolution() {
+        final String indexUrl1 = TEST_HTTP_URL + "/index1.m3u8";
+        final String indexUrl2 = TEST_HTTP_URL + "/index2.m3u8";
+        final int width = 640;
+        final int height = 360;
+        final float duration = 4.5f;
+        final String resText = width + "x" + height;
+        mFakeMRG.mHlsMockNetworkRequest = new HashMap<String, String>() { {
+                put(TEST_HTTP_HLS_URL,
+                        "#EXTM3U\n"
+                        + "#EXT-X-STREAM-INF:RESOLUTION=" + resText + ",CLOSED-CAPTIONS=NONE\n"
+                        + indexUrl1 + "\n"
+                        + "#EXT-X-STREAM-INF:RESOLUTION=704x396,CLOSED-CAPTIONS=NONE\n"
+                        + indexUrl2 + "\n");
+                put(indexUrl1,
+                        "#EXTM3U\n"
+                        + "#EXT-X-TARGETDURATION:10\n"
+                        + "#EXT-X-MEDIA-SEQUENCE:1\n"
+                        + "#EXTINF:" + duration + ",\n"
+                        + "http://www.test.com/segment1.ts,\n"
+                        + "#EXT-X-ENDLIST");
+                put(indexUrl2,
+                        "#EXTM3U\n"
+                        + "#EXT-X-TARGETDURATION:10\n"
+                        + "#EXT-X-MEDIA-SEQUENCE:1\n"
+                        + "#EXTINF:5.500,\n"
+                        + "http://www.test.com/segment1.ts,\n"
+                        + "#EXT-X-ENDLIST");
+            }};
+        MediaMetadata expected = new MediaMetadata((int) (duration * 1000), width, height, true);
+        assertEquals(expected, mFakeMRG.extract(mMockContext, TEST_HTTP_HLS_URL, null, null));
+    }
+
+    @SmallTest
+    public void testExtract_UsingHls_ValidMasterPlaylist_InValidResolution() {
+        final String indexUrl = TEST_HTTP_URL + "/index1.m3u8";
+        final float duration = 4.5f;
+        mFakeMRG.mHlsMockNetworkRequest = new HashMap<String, String>() { {
+                put(TEST_HTTP_HLS_URL,
+                        "#EXTM3U\n"
+                        + "#EXT-X-STREAM-INF:RESOLUTION=onextwo,CLOSED-CAPTIONS=NONE\n"
+                        + indexUrl + "\n");
+                put(indexUrl,
+                        "#EXTM3U\n"
+                        + "#EXT-X-TARGETDURATION:10\n"
+                        + "#EXT-X-MEDIA-SEQUENCE:1\n"
+                        + "#EXTINF:" + duration + ",\n"
+                        + "http://www.test.com/segment1.ts,\n"
+                        + "#EXT-X-ENDLIST");
+            }};
+        final MediaMetadata expected = new MediaMetadata((int) (duration * 1000), 0, 0, true);
+        assertEquals(expected, mFakeMRG.extract(mMockContext, TEST_HTTP_HLS_URL, null, null));
+    }
+
+    @SmallTest
+    public void testExtract_UsingHls_ValidMasterPlaylist_RelativeUrl() {
+        final String relativeUrl = "index1.m3u8";
+        final float duration = 4.5f;
+        mFakeMRG.mHlsMockNetworkRequest = new HashMap<String, String>() { {
+                put(TEST_HTTP_HLS_URL,
+                        "#EXTM3U\n"
+                        + "#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=845000,CLOSED-CAPTIONS=NONE\n"
+                        + relativeUrl + "\n");
+                put(TEST_HTTP_URL + "/" + relativeUrl,
+                        "#EXTM3U\n"
+                        + "#EXT-X-TARGETDURATION:10\n"
+                        + "#EXT-X-MEDIA-SEQUENCE:1\n"
+                        + "#EXTINF:" + duration + ",\n"
+                        + "http://www.test.com/segment1.ts,\n"
+                        + "#EXT-X-ENDLIST");
+            }};
+        final MediaMetadata expected = new MediaMetadata((int) (duration * 1000), 0, 0, true);
+        assertEquals(expected, mFakeMRG.extract(mMockContext, TEST_HTTP_HLS_URL, null, null));
     }
 }


### PR DESCRIPTION
Android Framework does not parse metadata for HLS playlists hence
added the required support in chromium MediaResourceGetter

crosswalk HEAD: crosswalk-17
chromium HEAD: 46.0.2490.86
