### PR TITLE
Support seekable Ranges and Play from Start

### DIFF
--- a/content/browser/media/android/browser_media_player_manager.cc
+++ b/content/browser/media/android/browser_media_player_manager.cc
@@ -343,6 +343,12 @@ void BrowserMediaPlayerManager::OnAudibleStateChanged(
       render_frame_host_, player_id, is_audible);
 }
 
+void BrowserMediaPlayerManager::OnSeekableRangeChanged(
+    int player_id, int seekableRangeStart, int seekableRangeEnd) {
+  Send(new MediaPlayerMsg_MediaSeekableRangeChanged(RoutingID(), player_id,
+      seekableRangeStart, seekableRangeEnd));
+}
+
 void BrowserMediaPlayerManager::OnWaitingForDecryptionKey(int player_id) {
   Send(new MediaPlayerMsg_WaitingForDecryptionKey(RoutingID(), player_id));
 }

--- a/content/browser/media/android/browser_media_player_manager.h
+++ b/content/browser/media/android/browser_media_player_manager.h
@@ -99,6 +99,7 @@ class CONTENT_EXPORT BrowserMediaPlayerManager
   void OnVideoSizeChanged(int player_id, int width, int height) override;
   void OnAudibleStateChanged(
       int player_id, bool is_audible_now) override;
+  void OnSeekableRangeChanged(int player_id, int seekableRangeStart, int seekableRangeEnd) override;
   void OnWaitingForDecryptionKey(int player_id) override;
 
   media::MediaResourceGetter* GetMediaResourceGetter() override;

--- a/content/common/media/media_player_messages_android.h
+++ b/content/common/media/media_player_messages_android.h
@@ -157,6 +157,12 @@ IPC_MESSAGE_ROUTED3(MediaPlayerMsg_MediaVideoSizeChanged,
                     int /* width */,
                     int /* height */)
 
+// Seekable Range has changed.
+IPC_MESSAGE_ROUTED3(MediaPlayerMsg_MediaSeekableRangeChanged,
+                    int /* player_id */,
+                    int /* seekableRangeStart */,
+                    int /* seekableRangeEnd */)
+
 // The current play time has updated.
 IPC_MESSAGE_ROUTED3(MediaPlayerMsg_MediaTimeUpdate,
                     int /* player_id */,

--- a/content/renderer/media/android/renderer_media_player_manager.cc
+++ b/content/renderer/media/android/renderer_media_player_manager.cc
@@ -40,6 +40,8 @@ bool RendererMediaPlayerManager::OnMessageReceived(const IPC::Message& msg) {
     IPC_MESSAGE_HANDLER(MediaPlayerMsg_MediaError, OnMediaError)
     IPC_MESSAGE_HANDLER(MediaPlayerMsg_MediaVideoSizeChanged,
                         OnVideoSizeChanged)
+    IPC_MESSAGE_HANDLER(MediaPlayerMsg_MediaSeekableRangeChanged,
+                        OnSeekableRangeChanged)
     IPC_MESSAGE_HANDLER(MediaPlayerMsg_MediaTimeUpdate, OnTimeUpdate)
     IPC_MESSAGE_HANDLER(MediaPlayerMsg_WaitingForDecryptionKey,
                         OnWaitingForDecryptionKey)
@@ -177,6 +179,14 @@ void RendererMediaPlayerManager::OnVideoSizeChanged(int player_id,
   WebMediaPlayerAndroid* player = GetMediaPlayer(player_id);
   if (player)
     player->OnVideoSizeChanged(width, height);
+}
+
+void RendererMediaPlayerManager::OnSeekableRangeChanged(int player_id,
+                                                    int seekableRangeStart,
+                                                    int seekableRangeEnd) {
+  WebMediaPlayerAndroid* player = GetMediaPlayer(player_id);
+  if (player)
+    player->OnSeekableRangeChanged(seekableRangeStart, seekableRangeEnd);
 }
 
 void RendererMediaPlayerManager::OnTimeUpdate(

--- a/content/renderer/media/android/renderer_media_player_manager.h
+++ b/content/renderer/media/android/renderer_media_player_manager.h
@@ -126,6 +126,7 @@ class RendererMediaPlayerManager : public RenderFrameObserver {
                        const base::TimeDelta& current_timestamp);
   void OnMediaError(int player_id, int error);
   void OnVideoSizeChanged(int player_id, int width, int height);
+  void OnSeekableRangeChanged(int player_id, int seekableRangeStart, int seekableRangeEnd);
   void OnTimeUpdate(int player_id,
                     base::TimeDelta current_timestamp,
                     base::TimeTicks current_time_ticks);

--- a/content/renderer/media/android/webmediaplayer_android.h
+++ b/content/renderer/media/android/webmediaplayer_android.h
@@ -195,6 +195,7 @@ class WebMediaPlayerAndroid : public blink::WebMediaPlayer,
   void OnSeekComplete(const base::TimeDelta& current_time);
   void OnMediaError(int error_type);
   void OnVideoSizeChanged(int width, int height);
+  void OnSeekableRangeChanged(int seekableRangeStart, int seekableRangeEnd);
   void OnDurationChanged(const base::TimeDelta& duration);
 
   // Called to update the current time.
@@ -527,6 +528,13 @@ class WebMediaPlayerAndroid : public blink::WebMediaPlayer,
   media::TimeDeltaInterpolator interpolator_;
 
   scoped_ptr<MediaSourceDelegate> media_source_delegate_;
+
+  // SeekableRange Start.
+  int seekableRangeStart_;
+
+  // SeekableRange End.
+  int seekableRangeEnd_;
+
 
   // NOTE: Weak pointers must be invalidated before all other member variables.
   base::WeakPtrFactory<WebMediaPlayerAndroid> weak_factory_;

--- a/media/base/android/java/src/org/chromium/media/MediaPlayerBridge.java
+++ b/media/base/android/java/src/org/chromium/media/MediaPlayerBridge.java
@@ -289,6 +289,10 @@ public class MediaPlayerBridge {
         getLocalPlayer().setOnErrorListener(listener);
     }
 
+    protected void setOnInfoListener(MediaPlayer.OnInfoListener listener) {
+        getLocalPlayer().setOnInfoListener(listener);
+    }
+
     protected void setOnPreparedListener(MediaPlayer.OnPreparedListener listener) {
         getLocalPlayer().setOnPreparedListener(listener);
     }

--- a/media/base/android/java/src/org/chromium/media/MediaPlayerListener.java
+++ b/media/base/android/java/src/org/chromium/media/MediaPlayerListener.java
@@ -9,6 +9,10 @@ import android.media.MediaPlayer;
 
 import org.chromium.base.annotations.CalledByNative;
 import org.chromium.base.annotations.JNINamespace;
+import org.chromium.base.Log;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 
 // This class implements all the listener interface for android mediaplayer.
 // Callbacks will be sent to the native class for processing.
@@ -18,6 +22,7 @@ class MediaPlayerListener implements MediaPlayer.OnPreparedListener,
         MediaPlayer.OnBufferingUpdateListener,
         MediaPlayer.OnSeekCompleteListener,
         MediaPlayer.OnVideoSizeChangedListener,
+        MediaPlayer.OnInfoListener,
         MediaPlayer.OnErrorListener {
     // These values are mirrored as enums in media/base/android/media_player_bridge.h.
     // Please ensure they stay in sync.
@@ -29,6 +34,10 @@ class MediaPlayerListener implements MediaPlayer.OnPreparedListener,
     // These values are copied from android media player.
     public static final int MEDIA_ERROR_MALFORMED = -1007;
     public static final int MEDIA_ERROR_TIMED_OUT = -110;
+
+    // These are the meta data keys for seekable ranges defined in native player with same keys
+    public static final int SEEKABLE_RANGE_START = 8193;
+    public static final int SEEKABLE_RANGE_END   = 8194;
 
     // Used to determine the class instance to dispatch the native call to.
     private long mNativeMediaPlayerListener = 0;
@@ -75,6 +84,39 @@ class MediaPlayerListener implements MediaPlayer.OnPreparedListener,
     }
 
     @Override
+    public boolean onInfo(MediaPlayer mp, int what, int extra) {
+        if (what == MediaPlayer.MEDIA_INFO_METADATA_UPDATE) {
+            try {
+                Method getMetadata = mp.getClass().getDeclaredMethod(
+                        "getMetadata", boolean.class, boolean.class);
+                getMetadata.setAccessible(true);
+                Object data = getMetadata.invoke(mp, false, false);
+                if (data != null) {
+                    Class<?> metadataClass = data.getClass();
+                    Method hasMethod = metadataClass.getDeclaredMethod("has", int.class);
+                    Boolean seekStartAvail = (Boolean)hasMethod.invoke(data, SEEKABLE_RANGE_START);
+                    Boolean seekEndAvail = (Boolean)hasMethod.invoke(data, SEEKABLE_RANGE_END);
+
+                    if (seekStartAvail == true && seekEndAvail == true) {
+                        Method getIntMethod = metadataClass.getDeclaredMethod("getInt", int.class);
+                        getIntMethod.setAccessible(true);
+                        int seekableRangeStart = (Integer) getIntMethod.invoke(data, SEEKABLE_RANGE_START);
+                        int seekableRangeEnd = (Integer) getIntMethod.invoke(data, SEEKABLE_RANGE_END);
+                        nativeOnSeekableRangeChanged(mNativeMediaPlayerListener, seekableRangeStart, seekableRangeEnd);
+                    }
+                }
+            } catch (NoSuchMethodException e) {
+                Log.e("OnInfo", "Cannot find MediaPlayer.getMetadata() method: " + e);
+            } catch (InvocationTargetException e) {
+                Log.e("OnInfo", "Cannot invoke MediaPlayer.getMetadata() method: " + e);
+            } catch (IllegalAccessException e) {
+                Log.e("OnInfo", "Cannot access metadata: " + e);
+            }
+        }
+        return true;
+    }
+
+    @Override
     public void onVideoSizeChanged(MediaPlayer mp, int width, int height) {
         nativeOnVideoSizeChanged(mNativeMediaPlayerListener, width, height);
     }
@@ -110,6 +152,7 @@ class MediaPlayerListener implements MediaPlayer.OnPreparedListener,
             mediaPlayerBridge.setOnErrorListener(listener);
             mediaPlayerBridge.setOnPreparedListener(listener);
             mediaPlayerBridge.setOnSeekCompleteListener(listener);
+            mediaPlayerBridge.setOnInfoListener(listener);
             mediaPlayerBridge.setOnVideoSizeChangedListener(listener);
         }
         return listener;
@@ -121,6 +164,10 @@ class MediaPlayerListener implements MediaPlayer.OnPreparedListener,
     private native void nativeOnMediaError(
             long nativeMediaPlayerListener,
             int errorType);
+
+    private native void nativeOnSeekableRangeChanged(
+            long nativeMediaPlayerListener,
+            int seekableRangeStart, int seekableRangeEnd);
 
     private native void nativeOnVideoSizeChanged(
             long nativeMediaPlayerListener,

--- a/media/base/android/media_player_android.cc
+++ b/media/base/android/media_player_android.cc
@@ -53,6 +53,10 @@ void MediaPlayerAndroid::OnVideoSizeChanged(int width, int height) {
   manager_->OnVideoSizeChanged(player_id(), width, height);
 }
 
+void MediaPlayerAndroid::OnSeekableRangeChanged(int seekableRangeStart, int seekableRangeEnd) {
+  manager_->OnSeekableRangeChanged(player_id(), seekableRangeStart, seekableRangeEnd);
+}
+
 void MediaPlayerAndroid::OnMediaError(int error_type) {
   manager_->OnError(player_id(), error_type);
 }

--- a/media/base/android/media_player_android.h
+++ b/media/base/android/media_player_android.h
@@ -109,6 +109,7 @@ class MEDIA_EXPORT MediaPlayerAndroid {
   // the events needed by MediaPlayerBridge. http://crbug.com/422597.
   // MediaPlayerListener callbacks.
   virtual void OnVideoSizeChanged(int width, int height);
+  virtual void OnSeekableRangeChanged(int seekableRangeStart, int seekableRangeEnd);
   virtual void OnMediaError(int error_type);
   virtual void OnBufferingUpdate(int percent);
   virtual void OnPlaybackComplete();

--- a/media/base/android/media_player_bridge.cc
+++ b/media/base/android/media_player_bridge.cc
@@ -396,6 +396,10 @@ void MediaPlayerBridge::OnVideoSizeChanged(int width, int height) {
   MediaPlayerAndroid::OnVideoSizeChanged(width, height);
 }
 
+void MediaPlayerBridge::OnSeekableRangeChanged(int seekableRangeStart, int seekableRangeEnd) {
+  MediaPlayerAndroid::OnSeekableRangeChanged(seekableRangeStart, seekableRangeEnd);
+}
+
 void MediaPlayerBridge::OnPlaybackComplete() {
   SetAudible(false);
   time_update_timer_.Stop();

--- a/media/base/android/media_player_bridge.h
+++ b/media/base/android/media_player_bridge.h
@@ -88,6 +88,7 @@ class MEDIA_EXPORT MediaPlayerBridge : public MediaPlayerAndroid {
 
   // MediaPlayerAndroid implementation.
   void OnVideoSizeChanged(int width, int height) override;
+  void OnSeekableRangeChanged(int seekableRangeStart, int seekableRangeEnd) override;
   void OnPlaybackComplete() override;
   void OnMediaInterrupted() override;
   void OnMediaPrepared() override;

--- a/media/base/android/media_player_listener.cc
+++ b/media/base/android/media_player_listener.cc
@@ -57,6 +57,13 @@ void MediaPlayerListener::OnVideoSizeChanged(
       width, height));
 }
 
+void MediaPlayerListener::OnSeekableRangeChanged(
+    JNIEnv* /* env */, jobject /* obj */, jint seekableRangeStart, jint seekableRangeEnd) {
+  task_runner_->PostTask(FROM_HERE, base::Bind(
+      &MediaPlayerAndroid::OnSeekableRangeChanged, media_player_,
+      seekableRangeStart, seekableRangeEnd));
+}
+
 void MediaPlayerListener::OnBufferingUpdate(
     JNIEnv* /* env */, jobject /* obj */, jint percent) {
   task_runner_->PostTask(FROM_HERE, base::Bind(

--- a/media/base/android/media_player_listener.h
+++ b/media/base/android/media_player_listener.h
@@ -36,6 +36,8 @@ class MediaPlayerListener {
   void OnMediaError(JNIEnv* /* env */, jobject /* obj */, jint error_type);
   void OnVideoSizeChanged(JNIEnv* /* env */, jobject /* obj */,
                           jint width, jint height);
+  void OnSeekableRangeChanged(JNIEnv* /* env */, jobject /* obj */,
+                          jint seekableRangeStart, jint seekableRangeEnd);
   void OnBufferingUpdate(JNIEnv* /* env */, jobject /* obj */, jint percent);
   void OnPlaybackComplete(JNIEnv* /* env */, jobject /* obj */);
   void OnSeekComplete(JNIEnv* /* env */, jobject /* obj */);

--- a/media/base/android/media_player_manager.h
+++ b/media/base/android/media_player_manager.h
@@ -63,6 +63,9 @@ class MEDIA_EXPORT MediaPlayerManager {
   // Called when video size has changed. Args: player ID, width, height.
   virtual void OnVideoSizeChanged(int player_id, int width, int height) = 0;
 
+  // Called when seekable range start or end value changed . Args: player ID, seekableRangeStart, seekableRangeEnd.
+  virtual void OnSeekableRangeChanged(int player_id, int seekableRangeStart, int seekableRangeEnd) = 0;
+
   // Called when the player thinks it stopped or started making sound.
   virtual void OnAudibleStateChanged(int player_id, bool is_audible_now) = 0;
 


### PR DESCRIPTION
Here is the flow of execution:
*) Listen for MEDIA_INFO_METADATA_UPDATE event
*) Get seekableRangeStart and seekableRangeEnd using getMetaData()
*) Propogate the values to native layer and to media_player_android
*) If seekableRanges have valid values, Send them to HTML Media Element
*) Fix clamping issues for current_time and duration for Live streams

crosswalk HEAD: crosswalk-17
chromium HEAD: 46.0.2490.86
