### PR TITLE
Don't release MediaPlayer for sliding seekable live streams until destructor called

### DIFF
--- a/media/base/android/media_player_bridge.h
+++ b/media/base/android/media_player_bridge.h
@@ -145,6 +145,11 @@ class MEDIA_EXPORT MediaPlayerBridge : public MediaPlayerAndroid {
   // Pending play event while player is preparing.
   bool pending_play_;
 
+  // is set when playing a live stream and seekable ranges are received in a sliding window fashion.
+  bool seekable_sliding_window_;
+
+  bool being_destroyed_;
+
   // Pending seek time while player is preparing.
   base::TimeDelta pending_seek_;
 


### PR DESCRIPTION
The seekable ranges still need to be updated even when system
goes into sleep state in the case of live streams so that the
player resumes to correct state after wake-up from system sleep.
The fix here involves avoiding releasing/resetting mediaplayer
resources when destructor for the mediaplayer is not called and
it is not a live stream case.